### PR TITLE
Fix layout overflow issues for screens between 768px and 1000px

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -508,3 +508,16 @@ dotlottie-player {
     background-color: gray;
   }
 /* DROPDOWN ENDS */
+
+/* Media query for screens between 768px and 1000px width */
+@media (max-width: 1000px) and (min-width: 768px) {
+    .container {
+        width: 90%;
+    }
+    .navbar {
+        width: 80%;
+    }
+    .landing-text {
+        font-size: 6rem;
+    }
+}


### PR DESCRIPTION
## Summary

This PR addresses layout issues for screens between 768px and 1000px wide, where certain elements such as `.container`, `.navbar`, and `.landing-text` were overflowing the viewport, causing the content to be cut off. The following changes were made to improve responsiveness:

- Adjusted `.container` and `.navbar` widths for better responsiveness in the 768px to 1000px range.
- Modified the font size for `.landing-text` to prevent text overflow on medium-sized screens.

## Changes

- **Added a media query for screens between 768px and 1000px:**  
  Adjusted the width of `.container` to 90% and `.navbar` to 80% to ensure they do not exceed the screen boundaries.
  
- **Adjusted the font size for `.landing-text` in the same media query:**  
  The font size was reduced to `6rem` to prevent it from overflowing on medium-sized screens.

## Screenshots

### Before

<img width="775" alt="before" src="https://github.com/user-attachments/assets/f9579710-1a42-45be-9fea-796d1fee13e0">


### After

<img width="852" alt="after" src="https://github.com/user-attachments/assets/f744edfb-9bb8-4ff6-9738-8da2af247702">


## Additional Notes

This fix aims to improve user experience by making the layout responsive for a wider range of screen sizes, especially between 768px and 1000px. The changes should not affect larger or smaller screen sizes outside of this range.